### PR TITLE
for loading pretrained model.

### DIFF
--- a/propagator/experiment.lua
+++ b/propagator/experiment.lua
@@ -163,6 +163,8 @@ function Experiment:model(model)
       if not torch.isTypeOf(model, 'nn.Serial') then
          self._model = nn.Serial(model)
          self._model:mediumSerial('double')
+      else
+         self._model = model
       end
       return
    end


### PR DESCRIPTION
otherwise it results:

    ../dp/propagator/experiment.lua:276: attempt to index field '_model' (a nil value)

when using the cuda-pretrained model via torch.load().