### PR TITLE
Fix non-working adaptive decay in examples

### DIFF
--- a/examples/convolutionneuralnetwork.lua
+++ b/examples/convolutionneuralnetwork.lua
@@ -229,7 +229,8 @@ xp = dp.Experiment{
          error_report = {'validator','feedback','confusion','accuracy'},
          maximize = true,
          max_epochs = opt.maxTries
-      }
+      },
+      ad
    },
    random_seed = os.time(),
    max_epoch = opt.maxEpoch

--- a/examples/neuralnetwork.lua
+++ b/examples/neuralnetwork.lua
@@ -157,7 +157,8 @@ xp = dp.Experiment{
          error_report = {'validator','feedback','confusion','accuracy'},
          maximize = true,
          max_epochs = opt.maxTries
-      }
+      },
+      ad
    },
    random_seed = os.time(),
    max_epoch = opt.maxEpoch


### PR DESCRIPTION
Some examples create an AdaptiveDecay but forget to register it as an observer. Because of that, the learning rate is not decayed with `--lrDecay adaptive`. This PR fixes that.